### PR TITLE
added back the interval timer

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@ pub enum GameEvent {
     KeyDown(event::KeyDownEvent),
     MouseDown(event::MouseDownEvent),
     MouseUp(event::MouseUpEvent),
+    Tick,
 }
 
 pub struct Point {


### PR DESCRIPTION
Felt like ripping out the interval timer was a bad idea, so I put it back. It's disabled by default. You can stick things in the GameEvent processor and set TICK_MS to make it work.