### PR TITLE
Clean up Clippy warnings; relax stdweb version requirement; etc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Stefan Mesken <KappaDistributive@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
-stdweb = "0.4.12"
+stdweb = "0.4"

--- a/src/game.rs
+++ b/src/game.rs
@@ -316,8 +316,7 @@ impl std::fmt::Display for Game {
                     for (z, &st) in cell_state.iter().enumerate() {
                         // calculate offset
                         let offset = 6 - cell_len / 2;
-                        let dest = (3 + y * 6) * (print_width + 1)
-                            + x * 12 + offset + z;
+                        let dest = (3 + y * 6) * (print_width + 1) + x * 12 + offset + z;
                         temp[dest] = st;
                     }
                 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -121,73 +121,6 @@ impl Game {
         }
     }
 
-    /// Creates a String representation of self.state as in
-    /// +-----------+-----------+-----------+-----------+
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |   32768   |           |           |           |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// +-----------+-----------+-----------+-----------+
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// +-----------+-----------+-----------+-----------+
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |           |           |   2048    |           |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// +-----------+-----------+-----------+-----------+
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// |           |    128    |           |    256    |
-    /// |           |           |           |           |
-    /// |           |           |           |           |
-    /// +-----------+-----------+-----------+-----------+
-    pub fn to_string(&self) -> String {
-        let print_width: usize = 1 + self.size * 12;
-        let print_height: usize = 1 + self.size * 6;
-        let mut temp: Vec<char> = Vec::new();
-
-        // create empty board with cell borders
-        for y in 0..print_height {
-            for x in 0..print_width {
-                match (y % 6, x % 12) {
-                    (0, 0) => temp.push('+'),
-                    (0, _) => temp.push('-'),
-                    (_, 0) => temp.push('|'),
-                    _ => temp.push(' '),
-                }
-            }
-            temp.push('\n');
-        }
-
-        // fill in cells with proper offset
-        for y in 0..self.size {
-            for x in 0..self.size {
-                if self.get_state(x, y) > 0 {
-                    // get cell value
-                    let cell_state: Vec<char> = self
-                        .get_state(x, y)
-                        .to_string()
-                        .chars()
-                        .collect::<Vec<char>>();
-                    let cell_len = cell_state.len();
-
-                    for z in 0..cell_len {
-                        // calculate offset
-                        let offset = 6 - cell_len / 2;
-                        temp[(3 + y * 6) * (print_width + 1) + x * 12 + offset + z] = cell_state[z];
-                    }
-                }
-            }
-        }
-        temp.iter().collect()
-    }
-
     pub fn set_state(&mut self, x: usize, y: usize, value: usize) {
         if x < self.size && y < self.size {
             self.board[y * self.size + x] = value;
@@ -321,5 +254,75 @@ impl Game {
             Direction::Right => (1, 0),
             Direction::Left => (-1, 0),
         }
+    }
+}
+
+impl std::fmt::Display for Game {
+    /// Creates a text representation of self.state as in
+    /// +-----------+-----------+-----------+-----------+
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |   32768   |           |           |           |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// +-----------+-----------+-----------+-----------+
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// +-----------+-----------+-----------+-----------+
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |           |           |   2048    |           |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// +-----------+-----------+-----------+-----------+
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// |           |    128    |           |    256    |
+    /// |           |           |           |           |
+    /// |           |           |           |           |
+    /// +-----------+-----------+-----------+-----------+
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let print_width: usize = 1 + self.size * 12;
+        let print_height: usize = 1 + self.size * 6;
+        let mut temp: Vec<char> = Vec::new();
+
+        // create empty board with cell borders
+        for y in 0..print_height {
+            for x in 0..print_width {
+                match (y % 6, x % 12) {
+                    (0, 0) => temp.push('+'),
+                    (0, _) => temp.push('-'),
+                    (_, 0) => temp.push('|'),
+                    _ => temp.push(' '),
+                }
+            }
+            temp.push('\n');
+        }
+
+        // fill in cells with proper offset
+        for y in 0..self.size {
+            for x in 0..self.size {
+                if self.get_state(x, y) > 0 {
+                    // get cell value
+                    let cell_state: Vec<char> = self
+                        .get_state(x, y)
+                        .to_string()
+                        .chars()
+                        .collect::<Vec<char>>();
+                    let cell_len = cell_state.len();
+                    for (z, &st) in cell_state.iter().enumerate() {
+                        // calculate offset
+                        let offset = 6 - cell_len / 2;
+                        let dest = (3 + y * 6) * (print_width + 1)
+                            + x * 12 + offset + z;
+                        temp[dest] = st;
+                    }
+                }
+            }
+        }
+        write!(f, "{}", temp.iter().collect::<String>())
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -29,7 +29,7 @@ impl Game {
     pub fn from_size(size: usize) -> Self {
         Game {
             board: vec![0; size * size],
-            size: size,
+            size,
             score: 0,
             best: 0,
             finished: false,
@@ -56,7 +56,7 @@ impl Game {
         }
     }
 
-    pub fn is_finished(self) -> bool {
+    pub fn is_finished(&self) -> bool {
         self.finished
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,10 +84,10 @@ fn main() {
                 // XXX Enable TICK_MS above and
                 // uncomment below to try out the
                 // interval timer.
-                
+
                 // canvas.clear_all();
                 false
-            },
+            }
         };
         if progress {
             game.seed_cell(get_seed());
@@ -100,8 +100,7 @@ fn main() {
     // The event processing closure needs to be mutably
     // shared between event handlers. Interior mutability
     // will work.
-    let process_event: Arc<Mutex<dyn FnMut(GameEvent)>> =
-        Arc::new(Mutex::new(process_event_fn));
+    let process_event: Arc<Mutex<dyn FnMut(GameEvent)>> = Arc::new(Mutex::new(process_event_fn));
 
     // Add event handler MouseDown
     document()
@@ -138,16 +137,13 @@ fn main() {
         }
     });
 
-
     // Set up and start a timer if needed.
     if TICK_MS.is_some() {
-        fn run_timer(process_event: Arc<Mutex<dyn FnMut(GameEvent)>>)
-        {
+        fn run_timer(process_event: Arc<Mutex<dyn FnMut(GameEvent)>>) {
             let process_event_clone = process_event.clone();
             stdweb::web::set_timeout(
                 move || {
-                    let process_event_fn =
-                        &mut *process_event_clone.lock().unwrap();
+                    let process_event_fn = &mut *process_event_clone.lock().unwrap();
                     process_event_fn(GameEvent::Tick);
                     run_timer(process_event);
                 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,8 @@ fn main() {
     // The event processing closure needs to be mutably
     // shared between event handlers. Interior mutability
     // will work.
-    let process_event: Arc<Mutex<Box<FnMut(GameEvent)>>> =
-        Arc::new(Mutex::new(Box::new(process_event_fn)));
+    let process_event: Arc<Mutex<dyn FnMut(GameEvent)>> =
+        Arc::new(Mutex::new(process_event_fn));
 
     // Add event handler MouseDown
     document()
@@ -144,7 +144,7 @@ fn main() {
 
     // Set up and start a timer if needed.
     if TICK_MS > 0 {
-        fn run_timer(process_event: Arc<Mutex<Box<FnMut(GameEvent)>>>)
+        fn run_timer(process_event: Arc<Mutex<dyn FnMut(GameEvent)>>)
         {
             stdweb::web::set_timeout({
                 let process_event_clone = process_event.clone();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use stdweb;
 use stdweb::unstable::TryInto;
 use stdweb::web::event;
 
@@ -30,23 +29,23 @@ impl Point {
 pub fn get_direction(last: &Point, current: &Point) -> Direction {
     if (last.x - current.x).abs() > (last.y - current.y).abs() {
         // move horizontal
-        return if last.x > current.x {
+        if last.x > current.x {
             Direction::Left
         } else {
             Direction::Right
-        };
+        }
     } else {
         // move vertical
-        return if last.y > current.y {
+        if last.y > current.y {
             Direction::Up
         } else {
             Direction::Down
-        };
+        }
     }
 }
 
 pub fn get_seed() -> usize {
     let rand = js! { return Math.random(); };
     let base: f64 = rand.try_into().unwrap();
-    (base * 1000000 as f64).floor() as usize
+    (base * 1_000_000.0).floor() as usize
 }


### PR DESCRIPTION
* Removed the third element from the `stdweb` version requirement in `Cargo.toml` to allow more updating.

* Fixed compiler warning about missing `dyn`.

* Fixed all the Clippy warnings.

* Cleaned up a bit of code.